### PR TITLE
Tunneling into web servers

### DIFF
--- a/proto/commands.proto
+++ b/proto/commands.proto
@@ -37,7 +37,9 @@ message SSHSessionData {
 
 message UISessionData {
     string tunnel_token = 1;
-    string protocol = 2;
+    string local_addr = 2;
+    uint32 local_port = 3;
+    string protocol = 4;
 }
 
 message ServerMessage {

--- a/wallguard-common/src/protobuf/wallguard_commands.rs
+++ b/wallguard-common/src/protobuf/wallguard_commands.rs
@@ -53,6 +53,10 @@ pub struct UiSessionData {
     #[prost(string, tag = "1")]
     pub tunnel_token: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
+    pub local_addr: ::prost::alloc::string::String,
+    #[prost(uint32, tag = "3")]
+    pub local_port: u32,
+    #[prost(string, tag = "4")]
     pub protocol: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/wallguard-server/src/datastore/models/remote_access_session.rs
+++ b/wallguard-server/src/datastore/models/remote_access_session.rs
@@ -70,6 +70,9 @@ impl RemoteAccessSession {
             "remote_access_session".into(),
             "remote_access_type".into(),
             "instance_id".into(),
+            "remote_access_local_addr".into(),
+            "remote_access_local_port".into(),
+            "remote_access_local_protocol".into(),
         ]
     }
 

--- a/wallguard-server/src/datastore/models/remote_access_session.rs
+++ b/wallguard-server/src/datastore/models/remote_access_session.rs
@@ -31,6 +31,12 @@ pub struct RemoteAccessSession {
     pub token: String,
     #[serde(rename = "remote_access_type")]
     pub r#type: RemoteAccessType,
+    #[serde(rename = "remote_access_local_addr")]
+    pub local_addr: Option<String>,
+    #[serde(rename = "remote_access_local_port")]
+    pub local_port: Option<u32>,
+    #[serde(rename = "remote_access_local_protocol")]
+    pub protocol: Option<String>,
 }
 
 impl RemoteAccessSession {
@@ -46,7 +52,16 @@ impl RemoteAccessSession {
             instance_id: instance_id.into(),
             token,
             r#type,
+            local_addr: None,
+            local_port: None,
+            protocol: None,
         }
+    }
+
+    pub fn set_ex_data(&mut self, addr: String, port: u32, protocol: String) {
+        self.local_addr = Some(addr);
+        self.local_port = Some(port);
+        self.protocol = Some(protocol);
     }
 
     pub fn pluck() -> Vec<String> {

--- a/wallguard-server/src/http_proxy/api/request_session.rs
+++ b/wallguard-server/src/http_proxy/api/request_session.rs
@@ -6,6 +6,7 @@ use actix_web::web::Json;
 use nullnet_liberror::Error;
 use serde::Deserialize;
 use serde_json::json;
+use std::net::IpAddr;
 
 use crate::app_context::AppContext;
 use crate::datastore::RemoteAccessSession;
@@ -14,11 +15,21 @@ use crate::datastore::SSHKeypair;
 use crate::http_proxy::utilities::authorization;
 use crate::http_proxy::utilities::error_json::ErrorJson;
 
+// We allow remote access to ANY HTTP/HTTPS web server that the client can relay traffic to.
+// We trust the user to know where they want to tunnel into, which is why this piece of data is included.
+#[derive(Deserialize)]
+struct SessionData {
+    local_addr: String,
+    local_port: u32,
+    protocol: String,
+}
+
 #[derive(Deserialize)]
 pub struct RequestPayload {
     device_id: String,
     instance_id: String,
     session_type: String,
+    data: Option<SessionData>,
 }
 
 pub async fn request_session(
@@ -46,7 +57,30 @@ pub async fn request_session(
         )));
     }
 
-    let session = RemoteAccessSession::new(&body.device_id, &body.instance_id, session_type);
+    let mut session = RemoteAccessSession::new(&body.device_id, &body.instance_id, session_type);
+
+    if matches!(session_type, RemoteAccessType::Ui) {
+        let Some(ex_data) = &body.data else {
+            return HttpResponse::InternalServerError().json(ErrorJson::from(
+                "Cannot create UI session: data block is missing",
+            ));
+        };
+
+        if !validate_ip_address(&ex_data.local_addr) {
+            return HttpResponse::InternalServerError().json(ErrorJson::from("Bad local_addr"));
+        }
+
+        if !validate_protocol(&ex_data.protocol) {
+            return HttpResponse::InternalServerError()
+                .json(ErrorJson::from("Unsupported protocol"));
+        }
+
+        session.set_ex_data(
+            ex_data.local_addr.clone(),
+            ex_data.local_port,
+            ex_data.protocol.clone(),
+        );
+    }
 
     if let Err(error) = context.datastore.create_session(&jwt, &session).await {
         return HttpResponse::InternalServerError().json(ErrorJson::from(format!(
@@ -79,4 +113,12 @@ async fn handle_ssh_edgecase(
         }
         Err(err) => Err(err),
     }
+}
+
+fn validate_ip_address(addr: &str) -> bool {
+    addr.parse::<IpAddr>().is_ok()
+}
+
+fn validate_protocol(proto: &str) -> bool {
+    matches!(proto.to_ascii_lowercase().as_str(), "http" | "https")
 }

--- a/wallguard-server/src/http_proxy/proxy/mod.rs
+++ b/wallguard-server/src/http_proxy/proxy/mod.rs
@@ -89,5 +89,13 @@ pub async fn proxy_http_request(
             .json(ErrorJson::from("Failed to adapt tunnel transport"));
     };
 
-    request::proxy_request(request, body, "domain.com", false, tunnel_adapter).await
+    request::proxy_request(
+        request,
+        body,
+        // TODO:
+        "domain.com",
+        protocol.to_lowercase() == "https",
+        tunnel_adapter,
+    )
+    .await
 }

--- a/wallguard-server/src/http_proxy/utilities/tunneling.rs
+++ b/wallguard-server/src/http_proxy/utilities/tunneling.rs
@@ -60,7 +60,6 @@ pub async fn establish_tunneled_tty(
 /// - `protocol`: The UI protocol string (to be replaced with enum in future)
 /// - `local_addr`: IP address of the local web server to connect to
 /// - `local_port`: Port of the local web server to connect to
-
 pub async fn establish_tunneled_ui(
     context: &AppContext,
     device_uuid: &str,

--- a/wallguard-server/src/orchestrator/client.rs
+++ b/wallguard-server/src/orchestrator/client.rs
@@ -184,6 +184,8 @@ impl Instance {
     pub async fn request_ui_session(
         &self,
         tunnel_token: impl Into<String>,
+        local_addr: impl Into<String>,
+        local_port: u32,
         protocol: impl Into<String>,
     ) -> Result<(), Error> {
         log::info!(
@@ -195,6 +197,8 @@ impl Instance {
         let ui_session_data = UiSessionData {
             tunnel_token: tunnel_token.into(),
             protocol: protocol.into(),
+            local_addr: local_addr.into(),
+            local_port: local_port.into(),
         };
 
         let message = ServerMessage {

--- a/wallguard-server/src/orchestrator/client.rs
+++ b/wallguard-server/src/orchestrator/client.rs
@@ -198,7 +198,7 @@ impl Instance {
             tunnel_token: tunnel_token.into(),
             protocol: protocol.into(),
             local_addr: local_addr.into(),
-            local_port: local_port.into(),
+            local_port,
         };
 
         let message = ServerMessage {

--- a/wallguard/src/control_channel/commands/open_ui_session_command.rs
+++ b/wallguard/src/control_channel/commands/open_ui_session_command.rs
@@ -1,6 +1,5 @@
-use std::net::SocketAddr;
-
 use nullnet_liberror::{location, Error, ErrorHandler, Location};
+use std::net::SocketAddr;
 use tokio::net::TcpStream;
 use wallguard_common::protobuf::wallguard_commands::UiSessionData;
 
@@ -21,14 +20,9 @@ impl ExecutableCommand for OpenUiSessionCommand {
     async fn execute(self) -> Result<(), Error> {
         log::debug!("Received OpenUiSessionCommand");
 
-        let addr: SocketAddr = match self.data.protocol.to_lowercase().as_str() {
-            "http" => "127.0.0.1:80".parse().unwrap(),
-            "https" => "127.0.0.1:443".parse().unwrap(),
-            _ => {
-                return Err(format!("Unsupported protocol: {}", self.data.protocol))
-                    .handle_err(location!())
-            }
-        };
+        let addr: SocketAddr = format!("{}:{}", self.data.local_addr, self.data.local_port)
+            .parse()
+            .handle_err(location!())?;
 
         let local_stream = TcpStream::connect(addr).await.handle_err(location!())?;
 


### PR DESCRIPTION
### Description:
This PR modifies both the client and server to support tunneling into arbitrary web servers, rather than being limited to a predefined target.

### Key Changes

- Implemented tunneling logic that allows connections to any web server specified by the user.
- Added support for specifying `local_addr`, `local_port`, and `protocol` in the request payload.

---
Related commit: https://github.com/NullNet-ai/datastore/commit/3cbc77a9f8576414fc8b8695551c2c33d516dfad