### PR TITLE
Potential fix for code scanning alert no. 29: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/NullNet-ai/wallguard/security/code-scanning/29](https://github.com/NullNet-ai/wallguard/security/code-scanning/29)

In general, the fix is to explicitly declare a `permissions` block for the workflow or for each job, limiting the `GITHUB_TOKEN` to the minimum required scopes. For a pure CI build/test workflow like this, `contents: read` is typically sufficient, because the only GitHub interaction required is fetching the repository contents (done by `actions/checkout`), which works with read‑only contents permissions.

The best fix here is to add a single root‑level `permissions` block under the workflow `name:` (before `on:`), so it applies to all jobs (`build-linux`, `build-windows`, `build-bsd`) without altering any step behavior. We set `contents: read` as a minimal, least‑privilege configuration. No other scopes appear needed for these jobs, and no existing steps will be affected negatively by read‑only contents permissions. No imports or additional definitions are required; this is a pure YAML configuration change in `.github/workflows/build.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
