### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,4 +1,5 @@
 name: Mirror
+permissions: {}
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/NullNet-ai/wallguard/security/code-scanning/1](https://github.com/NullNet-ai/wallguard/security/code-scanning/1)

To fix the problem, explicitly declare `permissions` for this workflow so that the `GITHUB_TOKEN` does not inherit broad repository defaults. Since this workflow only calls a reusable workflow for mirroring and passes a separate `GITLAB_TOKEN` secret, a safe minimal default is to set all default permissions to `none` at the workflow level. If the called workflow requires specific `GITHUB_TOKEN` permissions, those should be declared inside the called workflow itself; from the perspective of this file, we only need to ensure we are not over-privileging the token.

The best change with minimal functional impact is to add a root-level `permissions: {}` or `permissions: read-all`/`contents: read` block. To be maximally restrictive and still correct, we will set `permissions: {}` (equivalent to `GITHUB_TOKEN` having no permissions) so that this workflow cannot accidentally use `GITHUB_TOKEN` with elevated rights. This is done by adding a `permissions:` block after the `name:` line in `.github/workflows/mirror.yml`. No imports or additional methods are needed, as this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
